### PR TITLE
feat: 🍰 Release v1.0.8 – Configure Cookie Expire Time – second run

### DIFF
--- a/TODO-next-update.md
+++ b/TODO-next-update.md
@@ -7,6 +7,7 @@ When you overtake this deploy and rebrand repo to your network you have to recog
 ### PR – feat: 🍰 Configure Cookie Expire Time #43
 
 - You have to add the `COOKIE_EXPIRE_TIME` from the `deployment/kubernetes/values.template.yaml` to your `deployment/kubernetes/values.yaml` and set it to your prevered value.
+- Correct cookie exploration time in data privacy.
 
 ## Version 1.0.7 with 'ocelotDockerVersionTag' 1.0.7-171
 

--- a/TODO-next-update.md
+++ b/TODO-next-update.md
@@ -7,7 +7,7 @@ When you overtake this deploy and rebrand repo to your network you have to recog
 ### PR – feat: 🍰 Configure Cookie Expire Time #43
 
 - You have to add the `COOKIE_EXPIRE_TIME` from the `deployment/kubernetes/values.template.yaml` to your `deployment/kubernetes/values.yaml` and set it to your prevered value.
-- Correct cookie exploration time in data privacy.
+- Correct `locale` cookie exploration time in data privacy.
 
 ## Version 1.0.7 with 'ocelotDockerVersionTag' 1.0.7-171
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ocelot-social-branded",
-  "version": "1.0.7",
-  "ocelotDockerVersionTag": "1.0.7-171",
+  "version": "1.0.8",
+  "ocelotDockerVersionTag": "1.0.8-182",
   "dockerOrganisation": "ocelotsocialnetwork",
   "description": "ocelot.social Branded",
   "author": "ocelot.social Community",


### PR DESCRIPTION
## 🍰 Feature Ticket

- Release v1.0.8
- Configure cookie expire time.

fixes #42 

### Todo

- [x] release version v1.0.8, Docker version tag 1.0.8-182
- [x] add `COOKIE_EXPIRE_TIME` to `deployment/kubernetes/values.yaml`
- [x] add todo to correct `locale` cookie exploration date in data privacy

