### PR TITLE
chore: 🍰 Rename Neo4j Docker Image In General To `neo4j-community:*`

### DIFF
--- a/docker-compose.ocelotsocial-branded.yml
+++ b/docker-compose.ocelotsocial-branded.yml
@@ -2,10 +2,12 @@
 version: "3.4"
 
 services:
+
   ########################################################
   # WEBAPP ###############################################
   ########################################################
   webapp:
+    # name the image to match our image to be tested from our DockerHub repository so that it can be pulled from there, otherwise it will be created locally from the 'dockerfile'
     image: ocelotsocialnetwork/webapp-branded:latest
     ports:
       - 3000:3000
@@ -19,10 +21,12 @@ services:
       - MAPBOX_TOKEN="pk.eyJ1IjoiYnVzZmFrdG9yIiwiYSI6ImNraDNiM3JxcDBhaWQydG1uczhpZWtpOW4ifQ.7TNRTO-o9aK1Y6MyW_Nd4g"
       # - WEBSOCKETS_URI=ws://backend:4000/graphql # is not working and not given in Docker YAML in main repo
       - PUBLIC_REGISTRATION=true
+
   ########################################################
   # BACKEND ##############################################
   ########################################################
   backend:
+    # name the image to match our image to be tested from our DockerHub repository so that it can be pulled from there, otherwise it will be created locally from the 'dockerfile'
     image: ocelotsocialnetwork/backend-branded:latest
     networks:
       - test-network
@@ -47,10 +51,23 @@ services:
       - SMTP_HOST=mailserver
       - SMTP_PORT=25
       - SMTP_IGNORE_TLS=true
+
+  ########################################################
+  # MAINTENANCE ##########################################
+  ########################################################
+  maintenance:
+    # name the image to match our image to be tested from our DockerHub repository so that it can be pulled from there, otherwise it will be created locally from the 'dockerfile'
+    image: ocelotsocialnetwork/maintenance-branded:latest
+    networks:
+      - test-network
+    ports:
+      - 3001:80
+
   ########################################################
   # NEO4J ################################################
   ########################################################
   neo4j:
+    # name the image to match our image to be tested from our DockerHub repository so that it can be pulled from there, otherwise it will be created locally from the 'dockerfile'
     image: ocelotsocialnetwork/neo4j-community-branded:latest
     networks:
       - test-network
@@ -62,15 +79,7 @@ services:
       - 7687:7687
     volumes:
       - neo4j_data:/data
-  ########################################################
-  # MAINTENANCE ##########################################
-  ########################################################
-  maintenance:
-    image: ocelotsocialnetwork/maintenance-branded:latest
-    networks:
-      - test-network
-    ports:
-      - 5000:80
+
   ########################################################
   # MAILSERVER TO FAKE SMTP ##############################
   ########################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
 # This docker-compose file is just here for testing
+
 version: "3.4"
 
 services:
+
   ########################################################
   # WEBAPP ###############################################
   ########################################################
   webapp:
+    # name the image so that it cannot be found in a DockerHub repository, otherwise it will not be built locally from the 'dockerfile' but pulled from there
+    image: ocelotsocialnetwork/webapp-branded:local-production
     build:
       dockerfile: docker/webapp.Dockerfile
       target: branded
@@ -22,10 +26,13 @@ services:
       - MAPBOX_TOKEN="pk.eyJ1IjoiYnVzZmFrdG9yIiwiYSI6ImNraDNiM3JxcDBhaWQydG1uczhpZWtpOW4ifQ.7TNRTO-o9aK1Y6MyW_Nd4g"
       # - WEBSOCKETS_URI=ws://backend:4000/graphql # is not working and not given in Docker YAML in main repo
       - PUBLIC_REGISTRATION=true
+
   ########################################################
   # BACKEND ##############################################
   ########################################################
   backend:
+    # name the image so that it cannot be found in a DockerHub repository, otherwise it will not be built locally from the 'dockerfile' but pulled from there
+    image: ocelotsocialnetwork/backend-branded:local-production
     build:
       dockerfile: docker/backend.Dockerfile
       target: branded
@@ -53,11 +60,29 @@ services:
       - SMTP_HOST=mailserver
       - SMTP_PORT=25
       - SMTP_IGNORE_TLS=true
+
+  ########################################################
+  # MAINTENANCE ##########################################
+  ########################################################
+  maintenance:
+    # name the image so that it cannot be found in a DockerHub repository, otherwise it will not be built locally from the 'dockerfile' but pulled from there
+    image: ocelotsocialnetwork/maintenance-branded:local-production
+    build:
+      # TODO: Separate from webapp, this must be independent
+      dockerfile: docker/maintenance.Dockerfile
+      target: branded
+      context: .
+    networks:
+      - test-network
+    ports:
+      - 3001:80
+
   ########################################################
   # NEO4J ################################################
   ########################################################
   neo4j:
-    image: ocelotsocialnetwork/neo4j:community
+    # name the image so that it cannot be found in a DockerHub repository, otherwise it will not be built locally from the 'dockerfile' but pulled from there
+    image: ocelotsocialnetwork/neo4j-community-branded:local-production
     networks:
       - test-network
     volumes:
@@ -68,19 +93,7 @@ services:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
     ports:
       - 7687:7687
-  ########################################################
-  # MAINTENANCE ##########################################
-  ########################################################
-  maintenance:
-    build:
-      # TODO: Separate from webapp, this must be independent
-      dockerfile: docker/maintenance.Dockerfile
-      target: branded
-      context: .
-    networks:
-      - test-network
-    ports:
-      - 5000:80
+
   ########################################################
   # MAILSERVER TO FAKE SMTP ##############################
   ########################################################

--- a/docker/neo4j.Dockerfile
+++ b/docker/neo4j.Dockerfile
@@ -1,4 +1,4 @@
-ARG APP_IMAGE=ocelotsocialnetwork/neo4j
+ARG APP_IMAGE=ocelotsocialnetwork/neo4j-community
 ARG APP_IMAGE_TAG=latest
 ARG APP_IMAGE_COMMUNITY=${APP_IMAGE}:${APP_IMAGE_TAG}
 
@@ -10,4 +10,5 @@ FROM $APP_IMAGE_COMMUNITY as community-branded
 ##################################################################################
 # ENTERPRISE #####################################################################
 ##################################################################################
+# Todo: refactor this with 'APP_IMAGE', 'APP_IMAGE_TAG', and similar to 'APP_IMAGE_COMMUNITY', Neo4j 'dockerfile' from main code
 FROM ocelotsocialnetwork/neo4j-enterprise:latest as enterprise-branded


### PR DESCRIPTION
## 🍰 Pull Request

Rename Neo4j Docker image In general to `neo4j-community:*`.

- fixes #49

### Todo

- [x] rename `ocelotsocialnetwork/neo4j:<VERSION_TAG>` to `ocelotsocialnetwork/neo4j-community:<VERSION_TAG>`
- [ ] remove `ocelotsocialnetwork/neo4j:community` from our DockerHub repository?
- [x] search for `ARG APP_IMAGE=ocelotsocialnetwork/neo4j`
  - [x] change it to `ARG APP_IMAGE=ocelotsocialnetwork/neo4j-community`
    - [ ] when this has been done on the main code repository issue https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/4472
- [x] apply this change to main and rebranding repository
