### PR TITLE
chore: 🍰 Implement `PRODUCTION_DB_CLEAN_ALLOW` for Staging Production Environments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 55-implement-PRODUCTION_DB_CLEAN_ALLOW-for-staging-production-evironments # for testing while developing
+      # - 55-implement-PRODUCTION_DB_CLEAN_ALLOW-for-staging-production-evironments # for testing while developing
 
 jobs:
   ##############################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      # - 14-new-deployment-with-base-and-code # for testing while developing
+      - 5065-automatic-deployment-to-stage.ocelot.social-on-push-to-master-branch # for testing while developing
 
 jobs:
   ##############################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5065-automatic-deployment-to-stage.ocelot.social-on-push-to-master-branch # for testing while developing
+      - 55-implement-PRODUCTION_DB_CLEAN_ALLOW-for-staging-production-evironments # for testing while developing
 
 jobs:
   ##############################################################################

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -225,3 +225,50 @@ support, try this [helm chart](https://github.com/helm/charts/tree/master/stable
 
 On our kubernetes cluster we get "mult-attach" errors for persistent volumes.
 Apparently DigitalOcean's kubernetes clusters do not fulfill the requirements.
+
+## Kubernetes Commands (Without Helm) To Deploy New Docker Images To A Kubernetes Cluster
+
+### Deploy A Version
+
+```bash
+# !!! be aware of the correct kube context !!!
+$ kubectl config get-contexts
+
+# deploy version '$BUILD_VERSION'
+# !!! 'latest' is not recommended on production !!!
+
+# for easyness set env
+$ export BUILD_VERSION=1.0.8-48-ocelot.social1.0.8-184 # example
+# check this with
+$ echo $BUILD_VERSION
+1.0.8-48-ocelot.social1.0.8-184
+
+# deploy actual version '$BUILD_VERSION' to Kubernetes cluster
+$ kubectl -n default set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:$BUILD_VERSION
+$ kubectl -n default rollout restart deployment/ocelot-webapp
+$ kubectl -n default set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:$BUILD_VERSION
+$ kubectl -n default rollout restart deployment/ocelot-backend
+$ kubectl -n default set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:$BUILD_VERSION
+$ kubectl -n default rollout restart deployment/ocelot-maintenance
+$ kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:$BUILD_VERSION
+$ kubectl -n default rollout restart deployment/ocelot-neo4j
+# verify deployment and wait for the pods of each deployment to get ready for cleaning and seeding of the database
+$ kubectl -n default rollout status deployment/ocelot-webapp --timeout=240s
+$ kubectl -n default rollout status deployment/ocelot-maintenance --timeout=240s
+$ kubectl -n default rollout status deployment/ocelot-backend --timeout=240s
+$ kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
+```
+
+### Staging – Clean And Seed Neo4j Database
+
+***ATTENTION:*** Cleaning and seeding of our Neo4j database is only possible in production if env `PRODUCTION_DB_CLEAN_ALLOW=true` is set in our deployment.
+
+```bash
+# !!! be aware of the correct kube context !!!
+$ kubectl config get-contexts
+
+# reset and seed Neo4j database via backend for staging
+$ kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/clean.js"
+$ kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/seed.js"
+
+```

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -268,7 +268,7 @@ $ kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
 $ kubectl config get-contexts
 
 # reset and seed Neo4j database via backend for staging
-$ kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/clean.js"
-$ kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/seed.js"
+$ kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node --experimental-repl-await dist/db/clean.js && node --experimental-repl-await dist/db/seed.js"
+
 
 ```

--- a/deployment/kubernetes/templates/backend/ConfigMap.yml
+++ b/deployment/kubernetes/templates/backend/ConfigMap.yml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 data:
+  PRODUCTION_DB_CLEAN_ALLOW: "{{ .Values.PRODUCTION_DB_CLEAN_ALLOW }}"
   PUBLIC_REGISTRATION: "{{ .Values.PUBLIC_REGISTRATION }}"
   INVITE_REGISTRATION: "{{ .Values.INVITE_REGISTRATION }}"
   CLIENT_URI: "{{ .Values.BACKEND.CLIENT_URI }}"

--- a/deployment/kubernetes/values.template.yaml
+++ b/deployment/kubernetes/values.template.yaml
@@ -1,6 +1,7 @@
 # please duplicate template file and rename to "values.yaml" and fill in your value
 
 # change all the below if needed
+PRODUCTION_DB_CLEAN_ALLOW: false # only true for production environments on staging servers
 PUBLIC_REGISTRATION: false
 INVITE_REGISTRATION: false
 COOKIE_EXPIRE_TIME: 730 # days (730 days, two years is the default in main code)

--- a/docker-compose.ocelotsocial-branded.yml
+++ b/docker-compose.ocelotsocial-branded.yml
@@ -45,7 +45,7 @@ services:
       - PRIVATE_KEY_PASSPHRASE=a7dsf78sadg87ad87sfagsadg78
       - EMAIL_SUPPORT=support@wir.social
       - EMAIL_DEFAULT_SENDER=info@wir.social
-      - PRODUCTION_DB_CLEAN_ALLOW=true # because this is stage.ocelot.social # false # only true for production environments on staging servers
+      # - PRODUCTION_DB_CLEAN_ALLOW=false # only true for production environments on staging servers
       - PUBLIC_REGISTRATION=true
       - SMTP_USERNAME=${SMTP_USERNAME}
       - SMTP_PASSWORD=${SMTP_PASSWORD}

--- a/docker-compose.ocelotsocial-branded.yml
+++ b/docker-compose.ocelotsocial-branded.yml
@@ -45,6 +45,7 @@ services:
       - PRIVATE_KEY_PASSPHRASE=a7dsf78sadg87ad87sfagsadg78
       - EMAIL_SUPPORT=support@wir.social
       - EMAIL_DEFAULT_SENDER=info@wir.social
+      - PRODUCTION_DB_CLEAN_ALLOW=true # because this is stage.ocelot.social # false # only true for production environments on staging servers
       - PUBLIC_REGISTRATION=true
       - SMTP_USERNAME=${SMTP_USERNAME}
       - SMTP_PASSWORD=${SMTP_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - PRIVATE_KEY_PASSPHRASE=a7dsf78sadg87ad87sfagsadg78
       - EMAIL_SUPPORT=support@wir.social
       - EMAIL_DEFAULT_SENDER=info@wir.social
+      # - PRODUCTION_DB_CLEAN_ALLOW=false # only true for production environments on staging servers
       - PUBLIC_REGISTRATION=true
       - SMTP_USERNAME=${SMTP_USERNAME}
       - SMTP_PASSWORD=${SMTP_PASSWORD}


### PR DESCRIPTION
## 🍰 Pull Request

Implement `PRODUCTION_DB_CLEAN_ALLOW` for staging production environments.

- fixes #55

### Todo

- [ ] add release version, see #58
- [x] change back to publish on master branch push
- [x] set `PRODUCTION_DB_CLEAN_ALLOW` in `deployment/kubernetes/values.template.yaml`
- [x] set push branch temporary to this branch as well
- [x] document `Kubernetes Commands (Without Helm) To Deploy New Docker Images To A Kubernetes Cluster`
