### PR TITLE
chore: 🍰 Release v2.0.0 – Groups Etc. – Extend Rebranding And Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ __Try out our deployed [development environment](https://stage.ocelot.social).__
 
 Visit our staging networks:
 
-- central staging network: [stage.ocelot.social](https://stage.ocelot.social).
+- central staging network: [stage.ocelot.social](https://stage.ocelot.social)
 <!-- - rebranded staging network: [rebrand.ocelot.social](https://stage.ocelot.social). -->
 
 Logins:

--- a/TODO-next-update.md
+++ b/TODO-next-update.md
@@ -2,7 +2,7 @@
 
 When you overtake this deploy and rebrand repo to your network you have to recognize the following changes and doings …
 
-## This Latest Version >= 2.0.0 with 'ocelotDockerVersionTag' 2.0.0-XXX
+## This Latest Version >= 2.0.0 with 'ocelotDockerVersionTag' 2.0.0-250
 
 ### Main Code PR – feat: 🍰 Implement LOGO_HEADER_CLICK As Configuration #5525
 

--- a/TODO-next-update.md
+++ b/TODO-next-update.md
@@ -2,9 +2,19 @@
 
 When you overtake this deploy and rebrand repo to your network you have to recognize the following changes and doings …
 
+## This Latest Version >= 2.0.0 with 'ocelotDockerVersionTag' 2.0.0-XXX
+
+### Main Code PR – feat: 🍰 Implement LOGO_HEADER_CLICK As Configuration #5525
+
+- You have to set `LOGO_HEADER_CLICK` in `branding/constants/logos.js` originally in main code file `webapp/constants/logos.js` to your prevered value.
+
+### Main Code Issue – 🌟 [EPIC] Release v2.0.0 – Beta Test → Final #5547
+
+- You have to set `SHOW_GROUP_BUTTON_IN_HEADER` in `branding/constants/groups.js` originally in main code file `webapp/constants/groups.js` to your prevered value.
+
 ## This Latest Version >= 1.1.0 with 'ocelotDockerVersionTag' 1.1.0-205
 
-### Deployment/Rebranding PR –  chore: 🍰 Release v1.1.0 - Implement Categories Again #63
+### Deployment/Rebranding PR – chore: 🍰 Release v1.1.0 - Implement Categories Again #63
 
 - You have to add the `CATEGORIES_ACTIVE` from the `deployment/kubernetes/values.template.yaml` to your `deployment/kubernetes/values.yaml` and set it to your prevered value.
 - Make sure the correct categories are in your Neo4j database on the server.

--- a/branding/constants/groups.js
+++ b/branding/constants/groups.js
@@ -1,0 +1,5 @@
+// this file is duplicated in `backend/src/constants/group.js` and `webapp/constants/group.js`
+export const NAME_LENGTH_MIN = 3
+export const NAME_LENGTH_MAX = 50
+export const DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 100 // with removed HTML tags
+export const SHOW_GROUP_BUTTON_IN_HEADER = true

--- a/branding/constants/headerMenu.js
+++ b/branding/constants/headerMenu.js
@@ -1,12 +1,12 @@
 export default {
   MENU: [
     // {
-    //   name: 'Beiträge',
-    //   path: '/#',
+    //   nameIdent: 'nameIdent',
+    //   path: '/',
     // },
     // {
-    //   name: 'Über Yunite',
-    //   url: 'https://yunite.org',
+    //   nameIdent: 'nameIdent',
+    //   url: 'https://ocelot.social',
     // },
   ],
 }

--- a/branding/constants/logos.js
+++ b/branding/constants/logos.js
@@ -3,6 +3,15 @@
 export default {
   LOGO_HEADER_PATH: '/img/custom/logo-horizontal.svg',
   LOGO_HEADER_WIDTH: '130px',
+  LOGO_HEADER_CLICK: {
+    externalLink: null,
+    internalPath: {
+      to: {
+        name: 'index',
+      },
+      scrollTo: '.main-navigation',
+    },
+  },
   LOGO_SIGNUP_PATH: '/img/custom/logo-squared.svg',
   LOGO_WELCOME_PATH: '/img/custom/logo-squared.svg',
   LOGO_LOGOUT_PATH: '/img/custom/logo-squared.svg',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ocelot-social-branded",
-  "version": "1.1.1",
-  "ocelotDockerVersionTag": "1.1.1-228",
+  "version": "2.0.0",
+  "ocelotDockerVersionTag": "2.0.0-250",
   "dockerOrganisation": "ocelotsocialnetwork",
   "description": "ocelot.social Branded",
   "author": "ocelot.social Community",


### PR DESCRIPTION
## Pull-Request

Release v2.0.0 – groups etc. – extend rebranding and deployment

### Issues

fixes #76

### Todo

- [x] make version v2.0.0 in main code
- [x] #73
- [x] #75
- [x] set `LOGO_HEADER_CLICK`, see https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/5525
- [x] set build number in `TODO-next-update.md`
